### PR TITLE
Derive Debug on some types

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -43,6 +43,7 @@ pub struct PongPacket {
 }
 
 /// Error during parsing of a [PingPacket].
+#[derive(Clone, Debug, PartialEq)]
 pub enum ParsePingError {
     /// Ping packets must always be 12 bytes in size.
     InvalidSize,
@@ -79,6 +80,7 @@ impl From<PingPacket> for [u8; 12] {
 }
 
 /// Error during parsing of a [PongPacket].
+#[derive(Clone, Debug, PartialEq)]
 pub enum ParsePongError {
     /// Pong packets must always be 24 bytes in size.
     InvalidSize,


### PR DESCRIPTION
This PR derives `Debug`, `Clone`, and `PartialEq` on the types `ParsePingError` and `ParsePongError`. Currently, it's a bit unwieldy to use try_from to convert a slice to a PingPacket for example since the error can't be unwrapped, precisely because the error types don't implement `Debug`. Implementing `Debug` would make using try_from a lot nicer because of this.