### PR TITLE
Fix decoding of UDP ping packets

### DIFF
--- a/src/voice.rs
+++ b/src/voice.rs
@@ -144,9 +144,9 @@ impl<EncodeDst: VoicePacketDst, DecodeDst: VoicePacketDst> Decoder
         let kind = header >> 5;
         let target = header & 0b11111;
         let result = if kind == 1 {
-            VoicePacket::Ping {
-                timestamp: buf.read_varint()?,
-            }
+            let timestamp = buf.read_varint()?;
+            buf_mut.advance(buf_mut.len());
+            VoicePacket::Ping { timestamp }
         } else {
             let session_id = DecodeDst::read_session_id(&mut buf)?;
             let seq_num = buf.read_varint()?;


### PR DESCRIPTION
Currently, when UDP ping packets are being decoded, the buffer isn't advanced. This makes tokio interpret the decoded packet as data left that has yet to be decoded. Since decoded data can't be decoded again, this makes the decode function error out, leaving the bad bytes in the buffer. This makes the cycle repeat and prevents any UDP data from being decoded. To solve this, I simply made sure to discard the decoded data from the buffer.